### PR TITLE
$resource should not be string type

### DIFF
--- a/src/Events/ButtonClick.php
+++ b/src/Events/ButtonClick.php
@@ -8,11 +8,11 @@ class ButtonClick
 {
     use Dispatchable;
 
-    public string $resource;
+    public $resource;
 
     public ?string $key;
 
-    public function __construct(string $resource, ?string $key)
+    public function __construct($resource, ?string $key)
     {
         $this->resource = $resource;
         $this->key = $key;


### PR DESCRIPTION
We can't use ->save() or other eloquent methods on $resource if it's string type... It must be Resource type...