### PR TITLE
Remove PHP 8 `mixed` usage from ButtonController.php

### DIFF
--- a/src/Http/Controllers/ButtonController.php
+++ b/src/Http/Controllers/ButtonController.php
@@ -31,9 +31,8 @@ class ButtonController extends Controller
      * Trigger action
      *
      * @param NovaRequest $request
-     * @return mixed
      */
-    public function triggerAction(NovaRequest $request): mixed
+    public function triggerAction(NovaRequest $request)
     {
         $actionClass = $request->get('actionClass');
         $resourceId = $request->get('resourceId');


### PR DESCRIPTION
Hi, nice useful package you have here.

This PR removes usage of the PHP 8 `mixed` type, which is not available on PHP 7.4. The package says it requires PHP 7.4 or 8.  

When running with PHP 7.4, we get the following error message:

> Return value of Sietse85\NovaButton\Http\Controllers\ButtonController::triggerAction() must be an instance of Sietse85\NovaButton\Http\Controllers\mixed, array returned